### PR TITLE
	feat: resolve ES module default when resolving async components

### DIFF
--- a/src/core/global-api/use.js
+++ b/src/core/global-api/use.js
@@ -4,13 +4,11 @@ import { toArray } from '../util/index'
 
 export function initUse (Vue: GlobalAPI) {
   Vue.use = function (plugin: Function | Object) {
-    const cid = this.cid
-    if (!plugin._installed) {
-      plugin._installed = {}
-    }
-    if (plugin._installed[cid]) {
+    const installedPlugins = (this._installedPlugins || (this._installedPlugins = []))
+    if (installedPlugins.indexOf(plugin) > -1) {
       return this
     }
+
     // additional parameters
     const args = toArray(arguments, 1)
     args.unshift(this)
@@ -19,7 +17,7 @@ export function initUse (Vue: GlobalAPI) {
     } else if (typeof plugin === 'function') {
       plugin.apply(null, args)
     }
-    plugin._installed[cid] = true
+    installedPlugins.push(plugin)
     return this
   }
 }

--- a/test/unit/features/global-api/use.spec.js
+++ b/test/unit/features/global-api/use.spec.js
@@ -33,4 +33,20 @@ describe('Global API: use', () => {
     expect(Vue.options.directives['plugin-test']).toBeUndefined()
     expect(Ctor.options.directives['plugin-test']).toBe(def)
   })
+
+  // Github issue #5970
+  it('should work on multi version', () => {
+    const Ctor1 = Vue.extend({})
+    const Ctor2 = Vue.extend({})
+
+    Ctor1.use(pluginStub, options)
+    expect(Vue.options.directives['plugin-test']).toBeUndefined()
+    expect(Ctor1.options.directives['plugin-test']).toBe(def)
+
+    // multi version Vue Ctor with the same cid
+    Ctor2.cid = Ctor1.cid
+    Ctor2.use(pluginStub, options)
+    expect(Vue.options.directives['plugin-test']).toBeUndefined()
+    expect(Ctor2.options.directives['plugin-test']).toBe(def)
+  })
 })


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch for v2.x (or to a previous version branch), _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing: https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#development-setup
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
